### PR TITLE
Fix GLMod.login reference in MainMenuManagerStartPatch

### DIFF
--- a/GLMod/EventPatch/MainMenuManagerPatch.cs
+++ b/GLMod/EventPatch/MainMenuManagerPatch.cs
@@ -29,12 +29,12 @@ namespace GLMod
 
                     try
                     {
-                        CoroutineRunner.Run(GLMod.login(success =>
+                        CoroutineRunner.Run(GLMod.AuthService.Login(success =>
                         {
                             if (!GLMod.withUnityExplorer)
                             {
-                                CoroutineRunner.Run(GLMod.reloadItems());
-                                CoroutineRunner.Run(GLMod.reloadDlcOwnerships());
+                                CoroutineRunner.Run(GLMod.ItemService.ReloadItems());
+                                CoroutineRunner.Run(GLMod.ItemService.ReloadDlcOwnerships());
                             }
                         }));
                     }


### PR DESCRIPTION
- Update GLMod.login() to GLMod.AuthService.Login()
- Update GLMod.reloadItems() to GLMod.ItemService.ReloadItems()
- Update GLMod.reloadDlcOwnerships() to GLMod.ItemService.ReloadDlcOwnerships()

These methods were moved to services during the refactoring.