### PR TITLE
Debug authentication and service integration

### DIFF
--- a/GLMod/Services/ItemService.cs
+++ b/GLMod/Services/ItemService.cs
@@ -78,11 +78,10 @@ namespace GLMod.Services
                 _items.Clear();
                 var newItems = GLJson.Deserialize<List<GLItem>>(responseString);
                 _items.AddRange(newItems);
-                Log("Reload successes OK — " + _items.Count + " successes.");
             }
             catch (Exception ex)
             {
-                Log("Erreur : " + ex.Message);
+                Log("Erreur lors du chargement des items: " + ex.Message);
             }
         }
 
@@ -124,11 +123,10 @@ namespace GLMod.Services
                 _steamOwnerships.Clear();
                 var newOwnerships = GLJson.Deserialize<List<int>>(responseString);
                 _steamOwnerships.AddRange(newOwnerships);
-                Log("Reload DLC ownerships OK — " + _steamOwnerships.Count + " items.");
             }
             catch (Exception ex)
             {
-                Log("Erreur : " + ex.Message);
+                Log("Erreur lors du chargement des DLC ownerships: " + ex.Message);
             }
         }
 


### PR DESCRIPTION
- Create sequential TestAuthenticationServices coroutine to chain service tests
- Display results immediately after each service test completes
- Show structured output with clear sections for ItemService and RankService
- Include item count, DLC ownership count, and rank details in test output
- Remove duplicate logging from service methods to avoid redundancy
- Add necessary using statements for GLEntities and Collections

This provides a cleaner, more organized view of service initialization status.