### PR TITLE
Debug GLMod checksum verification issue

### DIFF
--- a/GLMod/EventPatch/MainMenuManagerPatch.cs
+++ b/GLMod/EventPatch/MainMenuManagerPatch.cs
@@ -27,24 +27,15 @@ namespace GLMod
                 GLMod.log("  Verifying GLMod integrity...");
 
                 bool? verificationResult = null;
-                string errorMessage = null;
 
                 yield return GLMod.IntegrityService.VerifyGLMod(
                     result =>
                     {
                         verificationResult = result;
-                    },
-                    error =>
-                    {
-                        errorMessage = error;
                     }
                 );
 
-                if (errorMessage != null)
-                {
-                    GLMod.log($"  [✗] Verification failed with error: {errorMessage}");
-                }
-                else if (verificationResult.HasValue)
+                if (verificationResult.HasValue)
                 {
                     if (verificationResult.Value)
                     {
@@ -52,7 +43,7 @@ namespace GLMod
                     }
                     else
                     {
-                        GLMod.log("  [✗] GLMod integrity check failed - checksum mismatch");
+                        GLMod.log("  [✗] GLMod integrity check failed (checksum mismatch or error)");
                     }
                 }
                 else

--- a/GLMod/GLMod.cs
+++ b/GLMod/GLMod.cs
@@ -230,11 +230,6 @@ namespace GLMod
 
         private void StartVerificationAndPatching()
         {
-            CoroutineRunner.Run(IntegrityService.VerifyGLMod(result =>
-            {
-                log("GLMod verified: " + result);
-            }));
-
             Harmony.PatchAll();
         }
 

--- a/GLMod/Services/IIntegrityService.cs
+++ b/GLMod/Services/IIntegrityService.cs
@@ -30,17 +30,15 @@ namespace GLMod.Services
         /// </summary>
         /// <param name="checksumId">Checksum ID</param>
         /// <param name="dllPath">Path to DLL file</param>
-        /// <param name="onComplete">Callback with verification result</param>
-        /// <param name="onError">Callback on error</param>
+        /// <param name="onComplete">Callback with verification result (true if valid, false if invalid or error)</param>
         /// <returns>Coroutine</returns>
-        IEnumerator VerifyDll(string checksumId, string dllPath, System.Action<bool> onComplete, System.Action<string> onError = null);
+        IEnumerator VerifyDll(string checksumId, string dllPath, System.Action<bool> onComplete);
 
         /// <summary>
         /// Verifies GLMod integrity
         /// </summary>
-        /// <param name="onComplete">Callback with verification result</param>
-        /// <param name="onError">Callback on error</param>
+        /// <param name="onComplete">Callback with verification result (true if valid, false if invalid or error)</param>
         /// <returns>Coroutine</returns>
-        IEnumerator VerifyGLMod(System.Action<bool> onComplete, System.Action<string> onError = null);
+        IEnumerator VerifyGLMod(System.Action<bool> onComplete);
     }
 }


### PR DESCRIPTION
Updated VerifyDll and VerifyGLMod methods to return false on errors instead of using onError callbacks. This simplifies error handling and makes the API cleaner by having all results go through the onComplete callback as boolean values (true for success, false for failure or error).

Changes:
- Remove onError parameter from VerifyDll and VerifyGLMod methods
- Return false via onComplete callback when errors occur
- Remove error logging from IntegrityService methods
- Remove duplicate VerifyGLMod call in StartVerificationAndPatching
- Update all callers to handle single boolean result