### PR TITLE
Fix HTTP 500 error in authentication service

### DIFF
--- a/GLMod/Services/IntegrityService.cs
+++ b/GLMod/Services/IntegrityService.cs
@@ -134,7 +134,10 @@ namespace GLMod.Services
         public IEnumerator VerifyGLMod(System.Action<bool> onComplete)
         {
             var pluginAttribute = typeof(GLMod).GetCustomAttribute<BepInPlugin>();
-            string version = pluginAttribute?.Version.ToString();
+            // Format version as Major.Minor.Build (3 components) to match server expectations
+            string version = pluginAttribute?.Version != null
+                ? $"{pluginAttribute.Version.Major}.{pluginAttribute.Version.Minor}.{pluginAttribute.Version.Build}"
+                : null;
             Log(version);
 
             bool result = false;


### PR DESCRIPTION
The issue was that Version.ToString() was returning a 4-component version string (e.g., "5.2.1.0") instead of the expected 3-component format (e.g., "5.2.1"). This caused the server to look for a checksum with the wrong version identifier, resulting in a 500 Internal Server Error.

Changed the version formatting to explicitly use Major.Minor.Build components to ensure consistency with server expectations.

Fixes the error: "getChecksum failed for glmod5.2.1, error: Response
status code does not indicate success: 500 (Internal Server Error)."