### PR TITLE
Add missing async functions to Integrity service

### DIFF
--- a/GLMod/Services/Interfaces/IIntegrityService.cs
+++ b/GLMod/Services/Interfaces/IIntegrityService.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Threading.Tasks;
 
 namespace GLMod.Services.Interfaces
 {
@@ -40,5 +41,37 @@ namespace GLMod.Services.Interfaces
         /// <param name="onComplete">Callback with verification result (true if valid, false if invalid or error)</param>
         /// <returns>Coroutine</returns>
         IEnumerator VerifyGLMod(System.Action<bool> onComplete);
+
+        #region Alternative Methods Without Coroutines (Async/Await)
+
+        /// <summary>
+        /// Alternative version of GetApiData using async/await instead of coroutines
+        /// </summary>
+        /// <param name="id">Data ID</param>
+        /// <returns>API data as string</returns>
+        Task<string> GetApiDataAsync(string id);
+
+        /// <summary>
+        /// Alternative version of GetChecksum using async/await instead of coroutines
+        /// </summary>
+        /// <param name="checksumId">Checksum ID</param>
+        /// <returns>Checksum as string</returns>
+        Task<string> GetChecksumAsync(string checksumId);
+
+        /// <summary>
+        /// Alternative version of VerifyDll using async/await instead of coroutines
+        /// </summary>
+        /// <param name="checksumId">Checksum ID</param>
+        /// <param name="dllPath">Path to DLL file</param>
+        /// <returns>True if valid, false otherwise</returns>
+        Task<bool> VerifyDllAsync(string checksumId, string dllPath);
+
+        /// <summary>
+        /// Alternative version of VerifyGLMod using async/await instead of coroutines
+        /// </summary>
+        /// <returns>True if valid, false otherwise</returns>
+        Task<bool> VerifyGLModAsync();
+
+        #endregion
     }
 }


### PR DESCRIPTION
Added the four async/await method signatures that were missing from the interface:
- GetApiDataAsync
- GetChecksumAsync
- VerifyDllAsync
- VerifyGLModAsync

These methods provide async/await alternatives to the existing coroutine-based methods.